### PR TITLE
Fix category

### DIFF
--- a/app/assets/stylesheets/components/_select2.scss
+++ b/app/assets/stylesheets/components/_select2.scss
@@ -11,10 +11,9 @@
   border-radius: 10px !important;
   height: calc(1.5em + 0.75rem + 2px) !important;
   padding: 0.375rem 0.75rem !important;
-  // font-family: inherit !important;
   font-size: 1rem !important;
   font-weight: 400 !important;
-  line-height: 0.9 !important;
+  line-height: 1.2 !important;
   color: #495057 !important;
   background-color: #fff !important;
   background-clip: padding-box !important;

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -11,20 +11,8 @@ class ActivitiesController < ApplicationController
       OR activities.address @@ :query \
     "
     selected_categories = Category.where(id: params[:category_ids])
-    if params[:query].present? && params[:category_ids].present?
-      @activities = Activity.joins(:categories).where(sql_query, query: "%#{params[:query]}%")
-      @activities = @activities.select do
-        @activities.each do |activity|
-          activity.categories.each do |category|
-            selected_categories.include?(category)
-          end
-        end
-      end
-      @activities.uniq!
-      @activities = Activity.where(id: @activities.map(&:id))
-    elsif params[:query].present?
-      @activities = Activity.where(sql_query, query: "%#{params[:query]}%")
-    elsif params[:category_ids].present?
+
+    if params[:category_ids].present?
       @activities = []
       Activity.all.each do |activity|
         activity.categories.each do |category|
@@ -34,6 +22,24 @@ class ActivitiesController < ApplicationController
       @activities.uniq!
       @activities = Activity.where(id: @activities.map(&:id))
     end
+    @activities = @activities.where(sql_query, query: "%#{params[:query]}%") if params[:query].present?
+    
+
+      # if params[:query].present? && params[:category_ids].present?
+      #   @activities = Activity.where(sql_query, query: "%#{params[:query]}%")
+      #   @activities = @activities.select do
+      #     @activities.each do |activity|
+      #       activity.categories.each do |category|
+      #         selected_categories.include?(category)
+      #       end
+      #     end
+      #   end
+      #   @activities.uniq!
+      #   @activities = Activity.where(id: @activities.map(&:id))
+      # elsif params[:query].present?
+      #   @activities = Activity.where(sql_query, query: "%#{params[:query]}%")
+        
+      # end
     @markers = @activities.geocoded.map do |activity|
       {
         lat: activity.latitude,

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -10,7 +10,7 @@
              %>
       </div>
       <div class="col-md-12 col-lg-5 d-flex justify-content-between align-items-center category-search">
-        <%= select_tag "category_ids", options_from_collection_for_select(@categories, "id", "name"), multiple: true, class: 'select2 flex-grow-1' %>
+        <%= select_tag "category_ids", options_from_collection_for_select(@categories, "id", "name", params[:category_ids]), multiple: true, value: params[:category_ids], class: 'select2 flex-grow-1' %>
         <%= submit_tag "Search", class:"btn btn-simple my-3"%>  
       </div>
     </div>


### PR DESCRIPTION
the filtering now works as in i can search for a place and then apply a category filter and it only shows results that have the search params and are in the categories.

Filtering by various categories still works as an || search rather than an && search. So for example "child friendly" and "free" will return all child friendly activities as well as all free activities (rather than activities that are child friendly and free).
We would have to change the whole controller setup to change this and Marcel suggested to not do that due to the risk of breaking things last minute.

Categories now also get displayed after the search.

I think it's reasonable to tick this feature of as is and move on. Let me know what you think

![Screenshot (43)](https://user-images.githubusercontent.com/64296477/121326810-2e1ac500-c913-11eb-8296-cb96a643a507.png)
